### PR TITLE
Add static side panel UI mockup

### DIFF
--- a/docs/sidepanel-design.css
+++ b/docs/sidepanel-design.css
@@ -1,0 +1,114 @@
+body {
+  margin: 0;
+  font-family: 'Noto Sans KR', sans-serif;
+}
+
+.sidebar {
+  width: 100%;
+  max-width: 360px;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  border: 1px solid #e0e0e0;
+  box-sizing: border-box;
+}
+
+.sidebar-header {
+  padding: 12px;
+  text-align: center;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.logo {
+  width: 32px;
+  height: 32px;
+}
+
+.start-btn {
+  display: block;
+  width: 100%;
+  background: #1d4ed8;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  padding: 10px 0;
+  margin: 12px 0;
+  font-size: 14px;
+  cursor: pointer;
+}
+
+.message-area {
+  flex: 1;
+  padding: 0 12px;
+  overflow-y: auto;
+}
+
+.message-bubble {
+  max-width: 80%;
+  padding: 8px 12px;
+  margin-bottom: 8px;
+  border-radius: 16px;
+  position: relative;
+  font-size: 14px;
+  background: #f3f4f6;
+}
+
+.message-bubble.left:after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: -8px;
+  border-width: 8px;
+  border-style: solid;
+  border-color: transparent #f3f4f6 transparent transparent;
+}
+
+.card-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  gap: 8px;
+  padding: 12px;
+}
+
+.card {
+  background: #fff;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  padding: 8px;
+  font-size: 14px;
+  text-align: center;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+}
+
+.input-area {
+  display: flex;
+  padding: 8px;
+  border-top: 1px solid #e0e0e0;
+  position: sticky;
+  bottom: 0;
+  background: #fff;
+}
+
+.message-input {
+  flex: 1;
+  padding: 8px;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  font-size: 14px;
+}
+
+.send-btn {
+  margin-left: 8px;
+  padding: 8px 12px;
+  background: #1d4ed8;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+@media (max-width: 480px) {
+  .sidebar {
+    max-width: none;
+  }
+}

--- a/docs/sidepanel-design.html
+++ b/docs/sidepanel-design.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Searchroid Side Panel UI</title>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="sidepanel-design.css" />
+  </head>
+  <body>
+    <div class="sidebar">
+      <header class="sidebar-header">
+        <img src="../chrome-extension/public/icons/icon-128.png" alt="Searchroid Logo" class="logo" />
+      </header>
+      <main class="sidebar-main">
+        <button class="start-btn">탐색 시작</button>
+        <div class="message-area">
+          <div class="message-bubble left">안녕하세요! 어떤 걸 도와드릴까요?</div>
+        </div>
+        <div class="card-list">
+          <div class="card">헤드라인 요약</div>
+          <div class="card">가격 비교</div>
+          <div class="card">리뷰 분석</div>
+          <div class="card">이미지 검색</div>
+        </div>
+      </main>
+      <footer class="input-area">
+        <input type="text" class="message-input" placeholder="메시지를 입력하세요" />
+        <button class="send-btn">전송</button>
+      </footer>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- design side panel layout with Noto Sans KR font
- include start button, speech bubble message area, scenario cards and input field

## Testing
- `pnpm -r test` *(fails: pnpm not found)*

------
https://chatgpt.com/codex/tasks/task_e_68466af085d0832ab1261c7d1d078243