### PR TITLE
Add example multi-agent modules

### DIFF
--- a/examples/multi-agent/config.ts
+++ b/examples/multi-agent/config.ts
@@ -1,0 +1,26 @@
+import { ChatOpenAI } from '@langchain/openai';
+import { ChatAnthropic } from '@langchain/anthropic';
+import { ChatGoogleGenerativeAI } from '@langchain/google-genai';
+import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
+
+export type Provider = 'openai' | 'anthropic' | 'gemini';
+
+export interface LLMConfig {
+  provider: Provider;
+  apiKey: string;
+  model?: string;
+}
+
+export function createChatModel(cfg: LLMConfig): BaseChatModel {
+  const { provider, apiKey, model } = cfg;
+  switch (provider) {
+    case 'openai':
+      return new ChatOpenAI({ apiKey, model: model ?? 'gpt-4o' });
+    case 'anthropic':
+      return new ChatAnthropic({ apiKey, model: model ?? 'claude-3-opus-20240229' });
+    case 'gemini':
+      return new ChatGoogleGenerativeAI({ apiKey, model: model ?? 'gemini-pro' });
+    default:
+      throw new Error(`Unknown provider: ${provider}`);
+  }
+}

--- a/examples/multi-agent/navigator.ts
+++ b/examples/multi-agent/navigator.ts
@@ -1,0 +1,27 @@
+export interface NavigateStep {
+  selector: string;
+  action: 'click' | 'input' | 'extract';
+  value?: string;
+}
+
+export class Navigator {
+  async execute(step: NavigateStep): Promise<string | undefined> {
+    const element = document.querySelector(step.selector) as HTMLElement | null;
+    if (!element) {
+      throw new Error(`Selector not found: ${step.selector}`);
+    }
+    switch (step.action) {
+      case 'click':
+        (element as HTMLElement).click();
+        break;
+      case 'input':
+        (element as HTMLInputElement).value = step.value ?? '';
+        break;
+      case 'extract':
+        return (element.textContent ?? '').trim();
+      default:
+        throw new Error(`Unknown action: ${step.action}`);
+    }
+    return undefined;
+  }
+}

--- a/examples/multi-agent/planner.ts
+++ b/examples/multi-agent/planner.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+import { HumanMessage } from '@langchain/core/messages';
+import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
+
+export const plannerOutputSchema = z.object({
+  web_task: z.string(),
+  next_steps: z.array(z.string()),
+  observation: z.string().optional(),
+  done: z.boolean(),
+});
+export type PlannerOutput = z.infer<typeof plannerOutputSchema>;
+
+export class Planner {
+  constructor(private readonly model: BaseChatModel) {}
+
+  async plan(command: string): Promise<PlannerOutput> {
+    const messages = [
+      new HumanMessage(`사용자 명령에 따라 웹 시나리오를 JSON 형태로 작성하세요.\n명령: ${command}`),
+    ];
+    const llm = this.model.withStructuredOutput(plannerOutputSchema, { includeRaw: false });
+    const res = await llm.invoke(messages);
+    if (!res.parsed) {
+      throw new Error('Planner 결과 파싱 실패');
+    }
+    return res.parsed;
+  }
+}

--- a/examples/multi-agent/validator.ts
+++ b/examples/multi-agent/validator.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod';
+import { HumanMessage } from '@langchain/core/messages';
+import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
+
+export const validationSchema = z.object({
+  isValid: z.boolean(),
+  summary: z.string(),
+});
+export type ValidationResult = z.infer<typeof validationSchema>;
+
+export class Validator {
+  constructor(private readonly model: BaseChatModel) {}
+
+  async validate(result: string): Promise<ValidationResult> {
+    const messages = [
+      new HumanMessage(`다음 결과를 평가하고 요약해주세요.\n\n${result}`),
+    ];
+    const llm = this.model.withStructuredOutput(validationSchema, { includeRaw: false });
+    const res = await llm.invoke(messages);
+    if (!res.parsed) {
+      throw new Error('Validator 결과 파싱 실패');
+    }
+    return res.parsed;
+  }
+}


### PR DESCRIPTION
## Summary
- prototype multi-agent architecture examples
- add Planner, Navigator, Validator modules
- add config for selecting LLM provider

## Testing
- `pnpm lint` *(fails: Request was cancelled due to network restriction)*

------
https://chatgpt.com/codex/tasks/task_e_68466af5a32c832ab3ff95736a963e20