### PR TITLE
Add task history log with rerun feature

### DIFF
--- a/packages/storage/lib/history/taskHistory.ts
+++ b/packages/storage/lib/history/taskHistory.ts
@@ -1,0 +1,48 @@
+import { createStorage } from '../base/base';
+import { StorageEnum } from '../base/enums';
+
+export interface TaskHistoryItem {
+  id: string;
+  task: string;
+  createdAt: number;
+}
+
+export interface TaskHistoryStorage {
+  addTask: (task: string) => Promise<TaskHistoryItem>;
+  getRecentTasks: (limit?: number) => Promise<TaskHistoryItem[]>;
+  clear: () => Promise<void>;
+}
+
+const TASK_HISTORY_KEY = 'task_history';
+
+const taskHistoryStorage = createStorage<TaskHistoryItem[]>(TASK_HISTORY_KEY, [], {
+  storageEnum: StorageEnum.Local,
+  liveUpdate: true,
+});
+
+export function createTaskHistoryStorage(): TaskHistoryStorage {
+  return {
+    addTask: async (task: string): Promise<TaskHistoryItem> => {
+      const item: TaskHistoryItem = {
+        id: crypto.randomUUID(),
+        task,
+        createdAt: Date.now(),
+      };
+      await taskHistoryStorage.set(prev => [item, ...prev]);
+      return item;
+    },
+
+    getRecentTasks: async (limit = 5): Promise<TaskHistoryItem[]> => {
+      const items = await taskHistoryStorage.get();
+      return [...items]
+        .sort((a, b) => b.createdAt - a.createdAt)
+        .slice(0, limit);
+    },
+
+    clear: async (): Promise<void> => {
+      await taskHistoryStorage.set([]);
+    },
+  };
+}
+
+export const taskHistoryStore = createTaskHistoryStorage();

--- a/packages/storage/lib/index.ts
+++ b/packages/storage/lib/index.ts
@@ -3,6 +3,7 @@ export * from './settings';
 export * from './chat';
 export * from './profile';
 export * from './prompt/favorites';
+export * from './history/taskHistory';
 
 // Re-export the favorites instance for direct use
 export { default as favoritesStorage } from './prompt/favorites';

--- a/pages/side-panel/src/components/TaskHistoryList.tsx
+++ b/pages/side-panel/src/components/TaskHistoryList.tsx
@@ -1,0 +1,41 @@
+import { Button } from '@extension/ui';
+import type { TaskHistoryItem } from '@extension/storage';
+
+interface TaskHistoryListProps {
+  tasks: TaskHistoryItem[];
+  onRerun: (task: string) => void;
+  isDarkMode?: boolean;
+}
+
+const TaskHistoryList: React.FC<TaskHistoryListProps> = ({
+  tasks,
+  onRerun,
+  isDarkMode = false,
+}) => {
+  if (tasks.length === 0) return null;
+
+  return (
+    <div className="p-2">
+      <h3 className={`mb-3 text-sm font-medium ${isDarkMode ? 'text-gray-200' : 'text-gray-700'}`}>Recent Tasks</h3>
+      <div className="space-y-2">
+        {tasks.map(task => (
+          <div
+            key={task.id}
+            className={`flex items-center justify-between rounded-lg p-2 ${isDarkMode ? 'bg-slate-800' : 'bg-white'}`}
+          >
+            <div className="truncate text-sm mr-2 flex-1">{task.task}</div>
+            <Button
+              theme={isDarkMode ? 'dark' : 'light'}
+              variant="secondary"
+              onClick={() => onRerun(task.task)}
+            >
+              Re-run
+            </Button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default TaskHistoryList;


### PR DESCRIPTION
## Summary
- store executed tasks in local storage
- expose task history store from storage package
- list recent tasks in side panel with ability to re-run

## Testing
- `pnpm -F chrome-extension test` *(fails: Error when performing the request)*

------
https://chatgpt.com/codex/tasks/task_e_68466affe318832abd7491fa9cde826c