### PR TITLE
Add export feature to side panel

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,0 +1,7 @@
+{
+  "googleSheetsApiKey": "",
+  "googleSheetsSpreadsheetId": "",
+  "notionApiKey": "",
+  "notionDatabaseId": "",
+  "slackWebhookUrl": ""
+}

--- a/pages/side-panel/src/SidePanel.tsx
+++ b/pages/side-panel/src/SidePanel.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { RxDiscordLogo } from 'react-icons/rx';
-import { FiSettings } from 'react-icons/fi';
+import { FiSettings, FiShare } from 'react-icons/fi';
 import { PiPlusBold } from 'react-icons/pi';
 import { GrHistory } from 'react-icons/gr';
 import { type Message, Actors, chatHistoryStore } from '@extension/storage';
@@ -11,6 +11,7 @@ import ChatInput from './components/ChatInput';
 import ChatHistoryList from './components/ChatHistoryList';
 import BookmarkList from './components/BookmarkList';
 import { EventType, type AgentEvent, ExecutionState } from './types/event';
+import { exportResult, type ExportFormat, type ExportPlatform } from './export';
 import './SidePanel.css';
 
 const SidePanel = () => {
@@ -595,6 +596,23 @@ const SidePanel = () => {
     }
   };
 
+  const handleExport = async () => {
+    try {
+      const platform = (window.prompt('Export platform (sheets|notion|slack)?', 'sheets') || 'sheets') as ExportPlatform;
+      const format = (window.prompt('Format (text|json|markdown)?', 'text') || 'text') as ExportFormat;
+      const content =
+        format === 'json'
+          ? JSON.stringify(messages, null, 2)
+          : format === 'markdown'
+            ? messages.map(m => `- ${m.actor}: ${m.content}`).join('\n')
+            : messages.map(m => `${m.actor}: ${m.content}`).join('\n');
+      await exportResult(platform, format, content);
+      console.log('Export success');
+    } catch (err) {
+      console.error('Export failed', err);
+    }
+  };
+
   // Load favorite prompts from storage
   useEffect(() => {
     const loadFavorites = async () => {
@@ -667,9 +685,18 @@ const SidePanel = () => {
               href="https://discord.gg/NN3ABHggMK"
               target="_blank"
               rel="noopener noreferrer"
-              className={`header-icon ${isDarkMode ? 'text-sky-400 hover:text-sky-300' : 'text-sky-400 hover:text-sky-500'}`}>
+              className={`header-icon ${isDarkMode ? 'text-sky-400 hover:text-sky-300' : 'text-sky-400 hover:text-sky-500'}`}> 
               <RxDiscordLogo size={20} />
             </a>
+            <button
+              type="button"
+              onClick={handleExport}
+              onKeyDown={e => e.key === 'Enter' && handleExport()}
+              className={`header-icon ${isDarkMode ? 'text-sky-400 hover:text-sky-300' : 'text-sky-400 hover:text-sky-500'} cursor-pointer`}
+              aria-label="Export"
+              tabIndex={0}>
+              <FiShare size={20} />
+            </button>
             <button
               type="button"
               onClick={() => chrome.runtime.openOptionsPage()}

--- a/pages/side-panel/src/export.ts
+++ b/pages/side-panel/src/export.ts
@@ -1,0 +1,84 @@
+import config from '../../config.json' assert { type: 'json' };
+
+export type ExportFormat = 'text' | 'json' | 'markdown';
+export type ExportPlatform = 'sheets' | 'notion' | 'slack';
+
+function resolveConfig(key: string): string | undefined {
+  const envKey = `VITE_${key.toUpperCase()}`;
+  return (import.meta.env[envKey as keyof ImportMetaEnv] as string | undefined) ||
+    (config as Record<string, string>)[key];
+}
+
+export async function exportToGoogleSheets(data: string, format: ExportFormat) {
+  const apiKey = resolveConfig('googleSheetsApiKey');
+  const spreadsheetId = resolveConfig('googleSheetsSpreadsheetId');
+  if (!apiKey || !spreadsheetId) throw new Error('Google Sheets configuration missing');
+
+  const body = {
+    values: [[data]],
+  };
+
+  const range = 'Sheet1!A1';
+  const url = `https://sheets.googleapis.com/v4/spreadsheets/${spreadsheetId}/values/${range}:append?valueInputOption=RAW&key=${apiKey}`;
+  await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+export async function exportToNotion(data: string, format: ExportFormat) {
+  const apiKey = resolveConfig('notionApiKey');
+  const databaseId = resolveConfig('notionDatabaseId');
+  if (!apiKey || !databaseId) throw new Error('Notion configuration missing');
+
+  const body = {
+    parent: { database_id: databaseId },
+    properties: {
+      title: {
+        title: [{ type: 'text', text: { content: new Date().toISOString() } }],
+      },
+    },
+    children: [
+      {
+        object: 'block',
+        type: 'paragraph',
+        paragraph: { text: [{ type: 'text', text: { content: data } }] },
+      },
+    ],
+  };
+
+  await fetch('https://api.notion.com/v1/pages', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+      'Notion-Version': '2022-06-28',
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+export async function exportToSlack(data: string, _format: ExportFormat) {
+  const webhookUrl = resolveConfig('slackWebhookUrl');
+  if (!webhookUrl) throw new Error('Slack configuration missing');
+
+  await fetch(webhookUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ text: data }),
+  });
+}
+
+export async function exportResult(platform: ExportPlatform, format: ExportFormat, content: string) {
+  switch (platform) {
+    case 'sheets':
+      return exportToGoogleSheets(content, format);
+    case 'notion':
+      return exportToNotion(content, format);
+    case 'slack':
+      return exportToSlack(content, format);
+    default:
+      throw new Error('Unsupported platform');
+  }
+}

--- a/vite-env.d.ts
+++ b/vite-env.d.ts
@@ -2,6 +2,11 @@
 
 interface ImportMetaEnv {
   readonly VITE_EXAMPLE: string;
+  readonly VITE_GOOGLE_SHEETS_API_KEY?: string;
+  readonly VITE_GOOGLE_SHEETS_SPREADSHEET_ID?: string;
+  readonly VITE_NOTION_API_KEY?: string;
+  readonly VITE_NOTION_DATABASE_ID?: string;
+  readonly VITE_SLACK_WEBHOOK_URL?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary
- add config.json with API placeholders
- extend environment types for export keys
- implement Google Sheets, Notion, and Slack exporters
- add export button and handler in the side panel UI

## Testing
- `pnpm lint` *(fails: Request was cancelled due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68466b05b3f8832a8e95bb548f8d39c5