### PR TITLE
Record LLM library name

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -1,1 +1,5 @@
 VITE_EXAMPLE=example
+# Specify the library of the LangChain chat model used
+# Used for logging when constructor names are minified
+VITE_LLM_LIBRARY=
+

--- a/README.md
+++ b/README.md
@@ -119,6 +119,9 @@ OpenAI Operator의 월 $200 가격표 없이 강력한 AI 웹 에이전트를 �
    pnpm dev
    ```
 
+7. **환경 변수 설정** (선택 사항)
+   * 번들 후 LLM 라이브러리 이름이 필요하면 `.env` 파일에 `VITE_LLM_LIBRARY=@langchain/openai` 와 같이 지정하세요.
+
 ## 🤖 모델 선택 가이드
 
 Searchroid는 각 에이전트마다 다른 LLM 모델을 설정해 성능과 비용을 조절할 수 있습니다. 다음은 권장 설정입니다.

--- a/chrome-extension/src/background/agent/agents/base.ts
+++ b/chrome-extension/src/background/agent/agents/base.ts
@@ -51,8 +51,7 @@ export abstract class BaseAgent<T extends z.ZodType, M = unknown> {
     this.chatLLM = options.chatLLM;
     this.prompt = options.prompt;
     this.context = options.context;
-    // TODO: fix this, the name is not correct in production environment
-    this.chatModelLibrary = this.chatLLM.constructor.name;
+    this.chatModelLibrary = this.getChatModelLibrary();
     this.modelName = this.getModelName();
     this.withStructuredOutput = this.setWithStructuredOutput();
     // extra options
@@ -74,6 +73,21 @@ export abstract class BaseAgent<T extends z.ZodType, M = unknown> {
       return this.chatLLM.model as string;
     }
     return 'Unknown';
+  }
+
+  // Determine the library that created this chat model
+  private getChatModelLibrary(): string {
+    // library property is set in helper when creating the model
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const lib = (this.chatLLM as any).library as string | undefined;
+    if (lib) {
+      return lib;
+    }
+    const envLib = import.meta.env.VITE_LLM_LIBRARY as string | undefined;
+    if (envLib) {
+      return envLib;
+    }
+    return this.chatLLM.constructor.name;
   }
 
   // Set the tool calling method

--- a/chrome-extension/src/background/agent/helper.ts
+++ b/chrome-extension/src/background/agent/helper.ts
@@ -11,6 +11,14 @@ import { ChatDeepSeek } from '@langchain/deepseek';
 
 const maxTokens = 1024 * 4;
 
+// Attach package information to the created chat model so that
+// we can reliably know which library is being used even after bundling
+function attachLibrary<T extends BaseChatModel>(model: T, library: string): T {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (model as any).library = library;
+  return model;
+}
+
 function isOpenAIOModel(modelName: string): boolean {
   if (modelName.startsWith('openai/')) {
     return modelName.startsWith('openai/o');
@@ -70,7 +78,7 @@ function createOpenAIChatModel(
     args.temperature = (modelConfig.parameters?.temperature ?? 0.1) as number;
     args.maxTokens = maxTokens;
   }
-  return new ChatOpenAI(args);
+  return attachLibrary(new ChatOpenAI(args), '@langchain/openai');
 }
 
 // Function to extract instance name from Azure endpoint URL
@@ -159,7 +167,7 @@ function createAzureChatModel(providerConfig: ProviderConfig, modelConfig: Model
     // DO NOT pass baseUrl or configuration here
   };
   // console.log('[createChatModel] Azure args passed to AzureChatOpenAI:', args);
-  return new AzureChatOpenAI(args);
+  return attachLibrary(new AzureChatOpenAI(args), '@langchain/openai');
 }
 
 // create a chat model based on the agent name, the model name and provider
@@ -189,7 +197,7 @@ export function createChatModel(providerConfig: ProviderConfig, modelConfig: Mod
         topP,
         clientOptions: {},
       };
-      return new ChatAnthropic(args);
+      return attachLibrary(new ChatAnthropic(args), '@langchain/anthropic');
     }
     case ProviderTypeEnum.DeepSeek: {
       const args = {
@@ -198,7 +206,7 @@ export function createChatModel(providerConfig: ProviderConfig, modelConfig: Mod
         temperature,
         topP,
       };
-      return new ChatDeepSeek(args) as BaseChatModel;
+      return attachLibrary(new ChatDeepSeek(args) as BaseChatModel, '@langchain/deepseek');
     }
     case ProviderTypeEnum.Gemini: {
       const args = {
@@ -207,7 +215,7 @@ export function createChatModel(providerConfig: ProviderConfig, modelConfig: Mod
         temperature,
         topP,
       };
-      return new ChatGoogleGenerativeAI(args);
+      return attachLibrary(new ChatGoogleGenerativeAI(args), '@langchain/google-genai');
     }
     case ProviderTypeEnum.Grok: {
       const args = {
@@ -218,7 +226,7 @@ export function createChatModel(providerConfig: ProviderConfig, modelConfig: Mod
         maxTokens,
         configuration: {},
       };
-      return new ChatXAI(args) as BaseChatModel;
+      return attachLibrary(new ChatXAI(args) as BaseChatModel, '@langchain/xai');
     }
     case ProviderTypeEnum.Groq: {
       const args = {
@@ -228,7 +236,7 @@ export function createChatModel(providerConfig: ProviderConfig, modelConfig: Mod
         topP,
         maxTokens,
       };
-      return new ChatGroq(args);
+      return attachLibrary(new ChatGroq(args), '@langchain/groq');
     }
     case ProviderTypeEnum.Cerebras: {
       const args = {
@@ -238,7 +246,7 @@ export function createChatModel(providerConfig: ProviderConfig, modelConfig: Mod
         topP,
         maxTokens,
       };
-      return new ChatCerebras(args);
+      return attachLibrary(new ChatCerebras(args), '@langchain/cerebras');
     }
     case ProviderTypeEnum.Ollama: {
       const args: {
@@ -264,7 +272,7 @@ export function createChatModel(providerConfig: ProviderConfig, modelConfig: Mod
         // TODO: configure the context window size in model config
         numCtx: 64000,
       };
-      return new ChatOllama(args);
+      return attachLibrary(new ChatOllama(args), '@langchain/ollama');
     }
     case ProviderTypeEnum.OpenRouter: {
       // Call the helper function, passing OpenRouter headers via the third argument


### PR DESCRIPTION
## Summary
- record the chat model library reliably by attaching a `library` field when creating chat models
- read that property in `BaseAgent` and fallback to `VITE_LLM_LIBRARY` env var
- document the new `VITE_LLM_LIBRARY` option

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.15.1.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_684673a24408832a9ab8cc4ee29d0d0b