### PR TITLE
Fix navigator action wait logic

### DIFF
--- a/chrome-extension/src/background/agent/agents/navigator.ts
+++ b/chrome-extension/src/background/agent/agents/navigator.ts
@@ -348,8 +348,9 @@ export class NavigatorAgent extends BaseAgent<z.ZodType, NavigatorResult> {
         if (this.context.paused || this.context.stopped) {
           return results;
         }
-        // TODO: wait for 1 second for now, need to optimize this to avoid unnecessary waiting
-        await new Promise(resolve => setTimeout(resolve, 1000));
+        // Wait for the page to stabilize before continuing to the next action
+        const page = await browserContext.getCurrentPage();
+        await page.waitForPageAndFramesLoad();
       } catch (error) {
         if (error instanceof URLNotAllowedError) {
           throw error;


### PR DESCRIPTION
## Summary
- use waitForPageAndFramesLoad instead of fixed timeout

## Testing
- `pnpm lint` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_684673a46f98832abcada37d09629b44