### PR TITLE
Fix optional action schema

### DIFF
--- a/chrome-extension/src/background/agent/actions/builder.ts
+++ b/chrome-extension/src/background/agent/actions/builder.ts
@@ -105,18 +105,18 @@ export class Action {
   }
 }
 
-// TODO: can not make every action optional, don't know why
 export function buildDynamicActionSchema(actions: Action[]): z.ZodType {
-  let schema = z.object({});
+  const shape: Record<string, z.ZodTypeAny> = {};
   for (const action of actions) {
     // create a schema for the action, it could be action.schema.schema or null
     // but don't use default: null as it causes issues with Google Generative AI
     const actionSchema = action.schema.schema;
-    schema = schema.extend({
-      [action.name()]: actionSchema.nullable().optional().describe(action.schema.description),
-    });
+    shape[action.name()] = actionSchema
+      .nullable()
+      .describe(action.schema.description);
   }
-  return schema;
+  // mark every action optional so the model can return only the actions it wants
+  return z.object(shape).partial();
 }
 
 export class ActionBuilder {

--- a/chrome-extension/test/buildDynamicActionSchema.test.ts
+++ b/chrome-extension/test/buildDynamicActionSchema.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { buildDynamicActionSchema, Action } from '../src/background/agent/actions/builder';
+import { doneActionSchema } from '../src/background/agent/actions/schemas';
+import { ActionResult } from '../src/background/agent/types';
+
+function createDummyAction() {
+  return new Action(async () => new ActionResult(), doneActionSchema);
+}
+
+describe('buildDynamicActionSchema', () => {
+  it('parses with missing action', () => {
+    const schema = buildDynamicActionSchema([createDummyAction()]);
+    expect(schema.parse({})).toEqual({});
+  });
+
+  it('parses provided action', () => {
+    const schema = buildDynamicActionSchema([createDummyAction()]);
+    const data = schema.parse({ done: { text: 'hi', success: true } });
+    expect(data.done.text).toBe('hi');
+  });
+});


### PR DESCRIPTION
## Summary
- build dynamic action schema by constructing shape then making it partial
- add tests for optional action parsing

## Testing
- `pnpm -F chrome-extension test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684673a59440832abcd6831c9f8dd9a8