### PR TITLE
Implement extract content action

### DIFF
--- a/chrome-extension/src/background/agent/actions/schemas.ts
+++ b/chrome-extension/src/background/agent/actions/schemas.ts
@@ -92,15 +92,15 @@ export const closeTabActionSchema: ActionSchema = {
   }),
 };
 
-// Content Actions, not used currently
-// export const extractContentActionSchema: ActionSchema = {
-//   name: 'extract_content',
-//   description:
-//     'Extract page content to retrieve specific information from the page, e.g. all company names, a specific description, all information about, links with companies in structured format or simply links',
-//   schema: z.object({
-//     goal: z.string(),
-//   }),
-// };
+export const extractContentActionSchema: ActionSchema = {
+  name: 'extract_content',
+  description:
+    'Extract page content to retrieve information relevant to the provided goal. If the goal is vague, summarize the page.',
+  schema: z.object({
+    intent: z.string().default('').describe('purpose of this action'),
+    goal: z.string(),
+  }),
+};
 
 // Cache Actions
 export const cacheContentActionSchema: ActionSchema = {

--- a/chrome-extension/src/background/browser/page.ts
+++ b/chrome-extension/src/background/browser/page.ts
@@ -15,6 +15,8 @@ import {
   getClickableElements as _getClickableElements,
   removeHighlights as _removeHighlights,
   getScrollInfo as _getScrollInfo,
+  getReadabilityContent as _getReadabilityContent,
+  type ReadabilityResult,
 } from '../dom/service';
 import { DOMElementNode, type DOMState } from '../dom/views';
 import { type BrowserContextConfig, DEFAULT_BROWSER_CONTEXT_CONFIG, type PageState, URLNotAllowedError } from './views';
@@ -197,6 +199,10 @@ export default class Page {
       throw new Error('Puppeteer page is not connected');
     }
     return await this._puppeteerPage.content();
+  }
+
+  async getReadabilityContent(): Promise<ReadabilityResult> {
+    return _getReadabilityContent(this._tabId);
   }
 
   async getState(useVision = false, cacheClickableElementsHashes = false): Promise<PageState> {

--- a/chrome-extension/test/extractContentAction.test.ts
+++ b/chrome-extension/test/extractContentAction.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { ActionBuilder } from '../src/background/agent/actions/builder';
+import type { AgentContext } from '../src/background/agent/types';
+import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
+
+function createBuilder() {
+  const context = {} as AgentContext;
+  const llm = { invoke: async () => ({ content: 'ok' }) } as unknown as BaseChatModel;
+  return new ActionBuilder(context, llm);
+}
+
+describe('ActionBuilder', () => {
+  it('includes extract_content action', () => {
+    const builder = createBuilder();
+    const actions = builder.buildDefaultActions();
+    const names = actions.map(a => a.name());
+    expect(names).toContain('extract_content');
+  });
+});


### PR DESCRIPTION
## Summary
- reimplement `extract_content` action and include it
- expose `getReadabilityContent` on `Page`
- add `extract_content` schema
- test that the action list includes the new action

## Testing
- `pnpm -F chrome-extension test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.15.1.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_684685c57e80832abcf5ffb82f355a4c